### PR TITLE
Switch to single DRS specs value

### DIFF
--- a/tables-cvs/cmor-cvs.json
+++ b/tables-cvs/cmor-cvs.json
@@ -3,8 +3,7 @@
         "Conventions": {
             "CF-1.11": "https://cfconventions.org/Data/cf-conventions/cf-conventions-1.11/cf-conventions.html",
             "CF-1.12": "https://cfconventions.org/Data/cf-conventions/cf-conventions-1.12/cf-conventions.html",
-            "CF-1.13": "https://cfconventions.org/Data/cf-conventions/cf-conventions-1.13/cf-conventions.html",
-            "CMIP-7.0": ""
+            "CF-1.13": "https://cfconventions.org/Data/cf-conventions/cf-conventions-1.13/cf-conventions.html"
         },
         "DRS": {
             "directory_path_example": "MIP-DRS7/CMIP7/CMIP/CNRM-CERFACS/CNRM-ESM2-1e/1pctCO2/r1i1p1f1/glb/mon/rsus/tavg-h2m-hxy-u/g101/20251104",
@@ -56,9 +55,7 @@
             "^[[:digit:]]\\{4\\}-[[:digit:]]\\{2\\}-[[:digit:]]\\{2\\}T[[:digit:]]\\{2\\}:[[:digit:]]\\{2\\}:[[:digit:]]\\{2\\}Z$"
         ],
         "data_specs_version": "MIP-DS7.1.0.0",
-        "drs_specs": {
-            "MIP-DRS7": "Data reference syntax (DRS) initially designed for use with CMIP7"
-        },
+        "drs_specs": "MIP-DRS7",
         "experiment_id": {
             "1pctCO2": {
                 "activity_id": [

--- a/tables-cvs/recreate-cmor-cvs-json.sh
+++ b/tables-cvs/recreate-cmor-cvs-json.sh
@@ -18,7 +18,7 @@
 # Environment variables that this file uses.
 # If they're not set, the default values are used.
 ESGVOC_FORK="${ESGVOC_FORK:=znichollscr}"
-ESGVOC_REVISION="${ESGVOC_REVISION:=41d901e2cf970f1d4bf4b6f9de42371c737b6aaa}"
+ESGVOC_REVISION="${ESGVOC_REVISION:=908dfeb3516aab1e3e3af8236ab66b43328e81cb}"
 # ESGVOC_FORK="${ESGVOC_FORK:=ESGF}"
 # ESGVOC_REVISION="${ESGVOC_REVISION:=7305a58}" # v3.0.0
 UNIVERSE_CVS_FORK="${UNIVERSE_CVS_FORK:=WCRP-CMIP}"

--- a/tables-cvs/requirements-cmor-cvs-table.txt
+++ b/tables-cvs/requirements-cmor-cvs-table.txt
@@ -15,7 +15,7 @@ debugpy==1.8.17
 decorator==5.2.1
 devtools==0.12.2
 distlib==0.4.0
-esgvoc @ git+https://github.com/znichollscr/esgf-vocab.git@cae7131ae8b409ed1b63563d7db8716de88abe09
+esgvoc @ git+https://github.com/znichollscr/esgf-vocab.git@908dfeb3516aab1e3e3af8236ab66b43328e81cb
 executing==2.2.1
 filelock==3.20.0
 flexcache==0.3


### PR DESCRIPTION
Motivated by an email chain to the CVs TT: this will ensure that the data specs version is taken from this file and cannot be overridden by the user (apparently this is the CMOR rule: single entries cannot be overridden)