### PR TITLE
climatology flag

### DIFF
--- a/scripts/construction.py
+++ b/scripts/construction.py
@@ -257,6 +257,10 @@ def dr_coord_to_cmor_dict(coord):
         cmor_coord['must_have_bounds'] = "yes"
     else:
         cmor_coord['must_have_bounds'] = "no"
+    if cmor_coord['climatology']:
+        cmor_coord['climatology'] = "yes"
+    else:
+        cmor_coord['climatology'] = ""
     # deal with lists
     if cmor_coord['requested']:
         try:

--- a/scripts/construction.py
+++ b/scripts/construction.py
@@ -257,10 +257,12 @@ def dr_coord_to_cmor_dict(coord):
         cmor_coord['must_have_bounds'] = "yes"
     else:
         cmor_coord['must_have_bounds'] = "no"
+
     if cmor_coord['climatology']:
         cmor_coord['climatology'] = "yes"
     else:
         cmor_coord['climatology'] = ""
+
     # deal with lists
     if cmor_coord['requested']:
         try:


### PR DESCRIPTION
Set to "yes" or "", as it was in CMIP6_coordinate.json, based on "Climatology Flag" column in CMIP7 DR Coordinates and Dimensions table

Addresses https://github.com/WCRP-CMIP/cmip7-cmor-tables/issues/69

So where previously `time2` had
```json
        "time2": {
            "axis": "T",
            "bounds_values": "",
            "climatology": true,
```
it will now have
```json
        "time2": {
            "axis": "T",
            "bounds_values": "",
            "climatology": "yes",
```
and similarly for `time3` and `time4`.