### PR TITLE
Change standard name of ps formula terms to surface_air_pressure

### DIFF
--- a/reference/MIP_formula_terms.json
+++ b/reference/MIP_formula_terms.json
@@ -132,7 +132,7 @@
             "dimensions": "longitude latitude time",
             "long_name": "Surface Air Pressure",
             "out_name": "ps",
-            "standard_name": "air_pressure",
+            "standard_name": "surface_air_pressure",
             "type": "real",
             "units": "Pa"
         },
@@ -140,7 +140,7 @@
             "dimensions": "longitude latitude time1",
             "long_name": "Surface Air Pressure",
             "out_name": "ps",
-            "standard_name": "air_pressure",
+            "standard_name": "surface_air_pressure",
             "type": "real",
             "units": "Pa"
         },
@@ -148,7 +148,7 @@
             "dimensions": "longitude latitude time2",
             "long_name": "Surface Air Pressure",
             "out_name": "ps",
-            "standard_name": "air_pressure",
+            "standard_name": "surface_air_pressure",
             "type": "real",
             "units": "Pa"
         },
@@ -156,7 +156,7 @@
             "dimensions": "latitude time1",
             "long_name": "Surface Air Pressure",
             "out_name": "ps",
-            "standard_name": "air_pressure",
+            "standard_name": "surface_air_pressure",
             "type": "real",
             "units": "Pa"
         },


### PR DESCRIPTION
Resolves #152

I regenerated the CMOR tables:
```
python construction.py v1.2.2.4 tables
```
and confirmed the update tables agree with the `DR-1.2.2.4-v1.0.2` tag except for the standard name change of these 4 `ps*` terms in CMIP7_formula_terms.json.

@taylor13 @matthew-mizielinski @sol1105 